### PR TITLE
Fix PowerShell Gallery preview badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ﻿<p align="center">
   <a href="https://www.powershellgallery.com/packages/PSHacktoberFest"><img src="https://img.shields.io/powershellgallery/v/PSHacktoberFest.svg"></a>
-  <a href="https://www.powershellgallery.com/packages/PSHacktoberFest"><img src="https://img.shields.io/powershellgallery/vpre/PSHacktoberFest.svg?label=powershell%20gallery%20preview&colorB=yellow"></a>
+  <a href="https://www.powershellgallery.com/packages/PSHacktoberFest"><img src="https://img.shields.io/powershellgallery/v/PSHacktoberFest.svg?label=powershell%20gallery%20preview&colorB=yellow&include_prereleases"></a>
   <a href="https://github.com/EvotecIT/PSHacktoberFest"><img src="https://img.shields.io/github/license/EvotecIT/PSHacktoberFest.svg"></a>
 </p>
 


### PR DESCRIPTION
Shields changed the PowerShell Gallery prerelease badge endpoint and the old vpre badge now renders a placeholder link.

This updates README badge URLs to use the normal PowerShell Gallery version badge with include_prereleases, so it displays the prerelease version again.

Ref: https://github.com/badges/shields/issues/11583